### PR TITLE
Избавились от  подписки класса  "ItForFree\SimpleMVC\ExceptionHandler". 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [0.x.x] 2021-01-21
+
+
+* Избавились от  подписки класса  `ItForFree\SimpleMVC\ExceptionHandler` (в его конструкторе вызовом функции [set_exception_handler](https://www.php.net/manual/ru/function.set-exception-handler.php)) на обработку всех ошибок, 
+потому что  сигнатура его же метода `ExceptionHandle::handleException(\Exception $exception)`
+не подразумевает обработку ошибок класса `Error` (к которым относятся напр. фатальные ошибки).
+

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@
 
 * `it-for-free/php-simple-assets` (менеджер JS и CSS): https://github.com/it-for-free/php-simple-assets
 
+## История изменений 
+
+* [Список основных изменений](CHANGELOG.md).
+

--- a/src/Application.php
+++ b/src/Application.php
@@ -69,7 +69,7 @@ class Application
 
             return $this;
         
-        } catch (Exception $exc) {
+        } catch (\Exception $exc) {
             $exceptionHandler->handleException($exc);
         }
     }

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -8,10 +8,7 @@ use ItForFree\SimpleMVC\exceptions\SmvcUsageException;
 
 class ExceptionHandler
 {
-    public function __construct()
-    {
-        set_exception_handler(array($this, 'handleException'));
-    }
+   
     
     /**
      * Метод обработки исключения. Проверяет существует ли пользовательский обработчик.

--- a/src/exceptions/SmvcCoreException.php
+++ b/src/exceptions/SmvcCoreException.php
@@ -4,7 +4,7 @@ namespace ItForFree\SimpleMVC\exceptions;
 class SmvcCoreException extends SmvcException
 {
     // Переопределим исключение так, что параметр message станет обязательным
-    public function __construct($message, $code = 0, Exception $previous = null) {
+    public function __construct($message, $code = 0, \Exception $previous = null) {
         // некоторый код 
     
         // убедитесь, что все передаваемые параметры верны

--- a/src/exceptions/SmvcException.php
+++ b/src/exceptions/SmvcException.php
@@ -4,7 +4,7 @@ namespace ItForFree\SimpleMVC\exceptions;
 class SmvcException extends \Exception
 {
     // Переопределим исключение так, что параметр message станет обязательным
-    public function __construct($message, $code = 0, Exception $previous = null) {
+    public function __construct($message, $code = 0, \Exception $previous = null) {
         // некоторый код 
     
         // убедитесь, что все передаваемые параметры верны

--- a/src/exceptions/SmvcRoutingException.php
+++ b/src/exceptions/SmvcRoutingException.php
@@ -7,7 +7,7 @@ namespace ItForFree\SimpleMVC\exceptions;
 class SmvcRoutingException extends SmvcUsageException
 {
     // Переопределим исключение так, что параметр message станет обязательным
-    public function __construct($message, $code = 404, Exception $previous = null) {
+    public function __construct($message, $code = 404, \Exception $previous = null) {
         // некоторый код 
 
         // убедитесь, что все передаваемые параметры верны

--- a/src/exceptions/SmvcUsageException.php
+++ b/src/exceptions/SmvcUsageException.php
@@ -8,7 +8,7 @@ namespace ItForFree\SimpleMVC\exceptions;
 class SmvcUsageException extends SmvcException
 {
     // Переопределим исключение так, что параметр message станет обязательным
-    public function __construct($message, $code = 0, Exception $previous = null) {
+    public function __construct($message, $code = 0, \Exception $previous = null) {
         // некоторый код 
     
         // убедитесь, что все передаваемые параметры верны


### PR DESCRIPTION
Избавились, потому что  сигнатура его же метода "ExceptionHandle::handleException(\Exception $exception)" не подразумевает обработку ошибок класса "Error" (к которым относятся напр. фатальные ошибки).